### PR TITLE
Fix PyPy import library name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,19 +274,11 @@ impl ImportLibraryGenerator {
     ///
     /// Returns the full import library file path under `out_dir`.
     fn implib_file_path(&self, out_dir: &Path, libext: &str) -> PathBuf {
-        let libname = match self.implementation {
-            PythonImplementation::CPython => match self.version {
-                Some((major, minor)) => {
-                    format!("python{}{}{}", major, minor, libext)
-                }
-                None => format!("python3{}", libext),
-            },
-            PythonImplementation::PyPy => match self.version {
-                Some((major, minor)) if (major, minor) >= (3, 9) => {
-                    format!("libpypy{}.{}-c{}", major, minor, libext)
-                }
-                _ => format!("libpypy3-c{}", libext),
-            },
+        let libname = match self.version {
+            Some((major, minor)) => {
+                format!("python{}{}{}", major, minor, libext)
+            }
+            None => format!("python3{}", libext),
         };
 
         let mut libpath = out_dir.to_owned();


### PR DESCRIPTION
PyPy uses `pythonXY.lib` to link to `libpypy3.Y-c`/`libpypy3-c`.

See https://github.com/PyO3/pyo3/pull/2506/files#r920773852