### PR TITLE
replace quansight-labs/setup-python with actions/setup-python

### DIFF
--- a/.github/workflows/dll.yml
+++ b/.github/workflows/dll.yml
@@ -7,7 +7,7 @@ jobs:
     name: Collect pythonXY.dll
     runs-on: windows-latest
     steps:
-      - uses: Quansight-Labs/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
           python-version: |
               pypy3.8


### PR DESCRIPTION
The changes in the fork were upstreamed and released in 5.5.0. See https://github.com/actions/setup-python/releases/tag/v5.5.0.