### PR TITLE
Set the crate MSRV to silence Clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "python3-dll-a"
 version = "0.2.14"
 edition = "2021"
+rust-version = "1.63"
 description = "Standalone python3(y)(t).dll import library generator"
 repository = "https://github.com/PyO3/python3-dll-a"
 authors = ["Sergey Kvachonok <ravenexp@gmail.com>", "messense <messense@icloud.com>", "Adam Reichold <adam.reichold@t-online.de>"]


### PR DESCRIPTION
Adopt the same MSRV policy as PyO3.